### PR TITLE
Fix sort_order parameter for Zoho requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 specs
 *.pyc
 config/.env
+venv/

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -294,6 +294,39 @@ async def test_zoho_api_request_async():
             assert mock_client.__aenter__.return_value.request.call_count == 1
 
 
+def test_zoho_api_request_converts_sort_order():
+    """Ensure sort_order is translated before the HTTP request."""
+    mock_response = httpx.Response(200, json={"data": "test"})
+
+    with patch("zoho_mcp.tools.api._get_access_token", return_value="token"):
+        with patch("httpx.Client") as mock_client_cls:
+            mock_client = mock_client_cls.return_value
+            mock_client.__enter__.return_value.request.return_value = mock_response
+
+            zoho_api_request("GET", "/test", params={"sort_order": "ascending"})
+
+            args, kwargs = mock_client.__enter__.return_value.request.call_args
+            assert kwargs["params"]["sort_order"] == "a"
+
+
+@pytest.mark.asyncio
+async def test_zoho_api_request_async_converts_sort_order():
+    """Ensure async requests translate sort_order."""
+    mock_response = httpx.Response(200, json={"data": "test"})
+
+    with patch("zoho_mcp.tools.api._get_access_token", return_value="token"):
+        with patch("httpx.AsyncClient") as mock_client_cls:
+            mock_client = mock_client_cls.return_value
+            mock_client.__aenter__.return_value.request.return_value = mock_response
+
+            await zoho_api_request_async(
+                "GET", "/test", params={"sort_order": "descending"}
+            )
+
+            args, kwargs = mock_client.__aenter__.return_value.request.call_args
+            assert kwargs["params"]["sort_order"] == "d"
+
+
 # Test credential validation
 def test_validate_credentials_success():
     """Test successful credential validation."""

--- a/zoho_mcp/tools/api.py
+++ b/zoho_mcp/tools/api.py
@@ -34,6 +34,17 @@ AUTH_BASE_URL = settings.ZOHO_AUTH_BASE_URL
 ORG_ID = settings.ZOHO_ORGANIZATION_ID
 
 
+def _translate_sort_order(params: Dict[str, Any]) -> None:
+    """Convert human readable sort order to Zoho compatible values."""
+    sort_order = params.get("sort_order")
+    if isinstance(sort_order, str):
+        value = sort_order.lower()
+        if value == "ascending":
+            params["sort_order"] = "a"
+        elif value == "descending":
+            params["sort_order"] = "d"
+
+
 # Legacy error classes for backward compatibility
 class ZohoAPIError(APIError):
     """Exception raised for errors in the Zoho API responses."""
@@ -293,14 +304,19 @@ async def zoho_api_request_async(
     """
     if params is None:
         params = {}
-    
+    else:
+        params = params.copy()
+
     # Generate or use provided request ID for tracing
     req_id = request_id or f"zoho-{uuid.uuid4().hex[:8]}"
     set_request_context(request_id=req_id)
-    
+
     # Add organization_id to every request
     if "organization_id" not in params and ORG_ID:
         params["organization_id"] = ORG_ID
+
+    # Convert sort order values if present
+    _translate_sort_order(params)
     
     # Ensure endpoint starts with /
     if not endpoint.startswith("/"):


### PR DESCRIPTION
## Summary
- normalize `sort_order` before sending requests
- add gitignore entry for `venv`
- test sort order conversion for sync and async API helpers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_684c6552d12c832880d2352fff12d99d